### PR TITLE
Return plain data if format is plain

### DIFF
--- a/handlers/BaseHandler.cfc
+++ b/handlers/BaseHandler.cfc
@@ -64,7 +64,9 @@ component extends="coldbox.system.EventHandler"{
 		// Magical renderings
 		event.renderData( 
 			type		= prc.response.getFormat(),
-			data 		= prc.response.getDataPacket(),
+			data 		= prc.response.getFormat() == "plain" ?
+					  prc.response.getData() :
+					  prc.response.getDataPacket(),
 			contentType = prc.response.getContentType(),
 			statusCode 	= prc.response.getStatusCode(),
 			statusText 	= prc.response.getStatusText(),


### PR DESCRIPTION
Trying to `renderData` a struct (the result of `getDataPacket`) fails when the format is `plain`.