### PR TITLE
Update BaseHandler.cfc

### DIFF
--- a/handlers/BaseHandler.cfc
+++ b/handlers/BaseHandler.cfc
@@ -25,9 +25,12 @@ component extends="coldbox.system.EventHandler"{
 	*/
 	function aroundHandler( event, rc, prc, targetAction, eventArguments ){
 		// Run the contents of this function block only once per request.
-		if ( event.getPrivateValue( "isFirstHandlerRun", true ) == false ) {
-			return;
-		}
+		if
+		(
+			event.valueExists( "isFirstHandlerRun" )
+			&&
+			event.getPrivateValue( "isFirstHandlerRun", true ) == false
+		)
 		try{
 			event.setPrivateValue( "isFirstHandlerRun", false );
 			// start a resource timer

--- a/handlers/BaseHandler.cfc
+++ b/handlers/BaseHandler.cfc
@@ -29,6 +29,7 @@ component extends="coldbox.system.EventHandler"{
 			return;
 		}
 		try{
+			event.setPrivateValue( "isFirstHandlerRun", false );
 			// start a resource timer
 			var stime = getTickCount();
 			// prepare our response object

--- a/handlers/BaseHandler.cfc
+++ b/handlers/BaseHandler.cfc
@@ -24,6 +24,10 @@ component extends="coldbox.system.EventHandler"{
 	* Around handler for all actions it inherits
 	*/
 	function aroundHandler( event, rc, prc, targetAction, eventArguments ){
+		// Run the contents of this function block only once per request.
+		if ( event.getPrivateValue( "isFirstHandlerRun", true ) == false ) {
+			return;
+		}
 		try{
 			// start a resource timer
 			var stime = getTickCount();


### PR DESCRIPTION
Logic to avoid running the aroundHandler more than once per request. This can happen if one Controller calls another via a framework function like `runEvent()`.